### PR TITLE
feat: only transfer objects that are enabled in renderer

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -310,6 +310,10 @@ class SendSceneOperator(bpy.types.Operator):
                 if obj.type == "GREASEPENCIL":
                     continue
 
+                # Only show objects that are active in the renderer
+                if obj.hide_render == True:
+                    continue
+
                # Evaluate mesh data with all current modifiers
                 eval_obj : bpy.types.Object = obj.evaluated_get(depsgraph)
 


### PR DESCRIPTION
Objects that are disabled in the renderer should not be imported in the game as these are undesirable and could be duplicates, pre-modifiers etc.

Only hides the meshes on first creation; there is no remove mesh functionality yet, so once a mesh is included, it cannot be removed. Feel free to ignore to do this in a better way if that is desired.