### PR TITLE
Ignore viewport visibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -313,8 +313,8 @@ class SendSceneOperator(bpy.types.Operator):
                 if obj.type == "GREASEPENCIL":
                     continue
 
-                # Only show objects that are active in the renderer
-                if obj.hide_render or not obj.visible_get():
+                # Only show objects that are active in the render
+                if obj.hide_render:
                     if isinstance(slotData, MeshSlotData):
                         # mesh was sent previously
                         meshSlotData : MeshSlotData = slotData


### PR DESCRIPTION
Viewport visibility is probably moreso just to allow you to edit without being blocked by other stuff, but you'd probably still want things hidden in viewport to transfer over